### PR TITLE
Fix error handling on argument error

### DIFF
--- a/source/cli/NFDriverCLI.cpp
+++ b/source/cli/NFDriverCLI.cpp
@@ -80,7 +80,7 @@ int main(int argc, const char *argv[]) {
   const std::string samplerate_string = "44100.0";
 #else
   if (argc < 2) {
-    std::cout << "Invalid number of arguments: ./NFDriver [samplerate]" << std::endl;
+    std::cerr << "Invalid number of arguments: ./NFDriver [samplerate]" << std::endl;
     return 1;
   }
   const std::string samplerate_string = argv[1];

--- a/source/cli/NFDriverCLI.cpp
+++ b/source/cli/NFDriverCLI.cpp
@@ -20,6 +20,8 @@
  */
 #include <NFDriver/NFDriver.h>
 
+#include <cstdlib>
+
 #define _USE_MATH_DEFINES
 #include <cmath>
 #include <iostream>
@@ -81,7 +83,7 @@ int main(int argc, const char *argv[]) {
 #else
   if (argc < 2) {
     std::cerr << "Invalid number of arguments: ./NFDriver [samplerate]" << std::endl;
-    return 1;
+    std::exit(1);
   }
   const std::string samplerate_string = argv[1];
 #endif


### PR DESCRIPTION
- Use standard error as output
- Use `exit` instead of `return`