### PR TITLE
Fix starting samples file bounce

### DIFF
--- a/source/NFDriverFileImplementation.cpp
+++ b/source/NFDriverFileImplementation.cpp
@@ -104,9 +104,13 @@ void NFDriverFileImplementation::run(NFDriverFileImplementation *driver) {
   fwrite(&header, 1, sizeof(header), fhandle);
 
   // Rendering.
-  float buffer[NF_DRIVER_SAMPLE_BLOCK_SIZE * NF_DRIVER_CHANNELS];
+  const auto buffer_samples = NF_DRIVER_SAMPLE_BLOCK_SIZE * NF_DRIVER_CHANNELS;
+  float buffer[buffer_samples];
   size_t numFrames = 0;
   while (driver->_run) {
+    for (int i = 0; i < buffer_samples; ++i) {
+      buffer[i] = 0.0f;
+    }
     driver->_will_render_callback(driver->_clientdata);
     numFrames =
         (size_t)driver->_render_callback(driver->_clientdata, buffer, NF_DRIVER_SAMPLE_BLOCK_SIZE);

--- a/source/NFDriverFileImplementation.cpp
+++ b/source/NFDriverFileImplementation.cpp
@@ -58,7 +58,9 @@ void NFDriverFileImplementation::setPlaying(bool playing) {
 
   if (!playing) {
     _run = false;
-    _thread->join();
+    if (std::this_thread::get_id() != _thread->get_id()) {
+      _thread->join();
+    }
     _thread = nullptr;
   } else {
     _run = true;


### PR DESCRIPTION
* Always set buffer samples to 0.0 before sending the samples to the API. Allows the consumer to not concern themselves with zeroing these samples themselves.
* Do not join the thread if currently on the same thread when playing is turned off